### PR TITLE
19 Refactor code out of src/extension.ts

### DIFF
--- a/src/commands/constants.ts
+++ b/src/commands/constants.ts
@@ -1,0 +1,6 @@
+// File for any constants used in commands
+
+// Review command constants
+export const CODE_REVIEW_INSTRUCTION =
+  "You are acting as GitHub Copilot. Return only code. Review the code and fix any bugs, then return the code.";
+export const CODE_REVIEW_PROGRESS_TITLE = "Reviewing code...";

--- a/src/commands/getReviewFileCodeCommand.ts
+++ b/src/commands/getReviewFileCodeCommand.ts
@@ -1,0 +1,34 @@
+import * as vscode from "vscode";
+import {
+  CODE_REVIEW_INSTRUCTION,
+  CODE_REVIEW_PROGRESS_TITLE,
+} from "./constants";
+import { doCompletion, displayDiff } from "../helpers";
+import { CompletionModel } from "../CompletionModel/CompletionModel";
+
+/**
+ * Queries the model for a reviewed, edited version of the current file contents.
+ * Displays a diff of the active editor document and the completion response.
+ */
+export const getReviewFileCodeCommand = (
+  completionModel: CompletionModel,
+): vscode.Disposable => {
+  const reviewFileCodeCommand = vscode.commands.registerCommand(
+    "vs-code-ai-extension.reviewFileCode",
+    async () => {
+      const code = vscode.window.activeTextEditor?.document.getText();
+      const modelInstruction = CODE_REVIEW_INSTRUCTION;
+      const progressTitle = CODE_REVIEW_PROGRESS_TITLE;
+
+      doCompletion(
+        completionModel,
+        code,
+        modelInstruction,
+        progressTitle,
+        (completion, activeEditor) =>
+          displayDiff(completion.completion, activeEditor),
+      );
+    },
+  );
+  return reviewFileCodeCommand;
+};

--- a/src/commands/getReviewSelectedCodeCommand.ts
+++ b/src/commands/getReviewSelectedCodeCommand.ts
@@ -1,0 +1,50 @@
+import * as vscode from "vscode";
+import {
+  doCompletion,
+  displayDiff,
+  getDocumentTextBeforeSelection,
+  getDocumentTextAfterSelection,
+} from "../helpers";
+import {
+  CODE_REVIEW_INSTRUCTION,
+  CODE_REVIEW_PROGRESS_TITLE,
+} from "./constants";
+import { CompletionModel } from "../CompletionModel/CompletionModel";
+
+/**
+ * Queries the model for a reviewed, edited version of the currently selected code.
+ * Displays a diff of the active editor document and the completion response in context of the overall file.
+ */
+export const getReviewSelectedCodeCommand = (
+  completionModel: CompletionModel,
+): vscode.Disposable => {
+  return vscode.commands.registerCommand(
+    "vs-code-ai-extension.reviewSelectedCode",
+    async () => {
+      const code = vscode.window.activeTextEditor?.document.getText(
+        vscode.window.activeTextEditor?.selection,
+      );
+      const modelInstruction = CODE_REVIEW_INSTRUCTION;
+      const progressTitle = CODE_REVIEW_PROGRESS_TITLE;
+
+      doCompletion(
+        completionModel,
+        code,
+        modelInstruction,
+        progressTitle,
+        (completion, activeEditor) => {
+          const documentTextBeforeSelection =
+            getDocumentTextBeforeSelection(activeEditor);
+          const documentTextAfterSelection =
+            getDocumentTextAfterSelection(activeEditor);
+
+          const diffContent =
+            documentTextBeforeSelection +
+            completion.completion +
+            documentTextAfterSelection;
+          displayDiff(diffContent, activeEditor);
+        },
+      );
+    },
+  );
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,18 +1,11 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from "vscode";
-import { injectCompletionModel } from "./helpers/injectCompletionModel";
-import { CompletionModelResponse } from "./CompletionModel/CompletionModel";
+import { injectCompletionModel } from "./helpers";
+import { getReviewFileCodeCommand } from "./commands/getReviewFileCodeCommand";
+import { getReviewSelectedCodeCommand } from "./commands/getReviewSelectedCodeCommand";
 
-const codeReviewInstruction =
-  "You are acting as GitHub Copilot. Return only code. Review the code and fix any bugs, then return the code.";
-const codeReviewProgressTitle = "Reviewing code...";
-
-// This method is called when your extension is activated
-// Your extension is activated the very first time the command is executed
+// This method is called when the extension is activated
+// The extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-  // Use the console to output diagnostic information (console.log) and errors (console.error)
-  // This line of code will only be executed once when your extension is activated
   console.log(
     'Congratulations, your extension "vs-code-ai-extension" is now active!',
   );
@@ -25,155 +18,14 @@ export function activate(context: vscode.ExtensionContext) {
   // provide the implementation with registerCommand.
   // The commandId parameter must match the command field in package.json
 
-  /**
-   * Queries the model for a reviewed, edited version of the current file contents. Displays a diff of the active editor document and the completion response.
-   */
-  const reviewFileCodeCommand = vscode.commands.registerCommand(
-    "vs-code-ai-extension.reviewFileCode",
-    async () => {
-      const code = vscode.window.activeTextEditor?.document.getText();
-      const modelInstruction = codeReviewInstruction;
-      const progressTitle = codeReviewProgressTitle;
-
-      getCompletion(
-        code,
-        modelInstruction,
-        progressTitle,
-        (completion, activeEditor) =>
-          displayDiff(completion.completion, activeEditor),
-      );
-    },
-  );
-
-  /**
-   * Queries the model for a reviewed, edited version of the currently selected code. Displays a diff of the active editor document and the completion response in context of the overall file.
-   */
-  const reviewSelectedCodeCommand = vscode.commands.registerCommand(
-    "vs-code-ai-extension.reviewSelectedCode",
-    async () => {
-      const code = vscode.window.activeTextEditor?.document.getText(
-        vscode.window.activeTextEditor?.selection,
-      );
-      const modelInstruction = codeReviewInstruction;
-      const progressTitle = codeReviewProgressTitle;
-
-      getCompletion(
-        code,
-        modelInstruction,
-        progressTitle,
-        (completion, activeEditor) => {
-          const documentTextBeforeSelection = activeEditor.document.getText(
-            new vscode.Range(
-              new vscode.Position(0, 0),
-              activeEditor.selection.start,
-            ),
-          );
-          const documentTextAfterSelection = activeEditor.document.getText(
-            new vscode.Range(
-              activeEditor.selection.end,
-              new vscode.Position(
-                activeEditor.document.lineCount - 1,
-                activeEditor.document.lineAt(
-                  activeEditor.document.lineCount - 1,
-                ).text.length,
-              ),
-            ),
-          );
-
-          const diffContent =
-            documentTextBeforeSelection +
-            completion.completion +
-            documentTextAfterSelection;
-          displayDiff(diffContent, activeEditor);
-        },
-      );
-    },
-  );
-
-  /**
-   * Displays a diff comparison of the active editor document and the provided content in a new editor.
-   *
-   * @param diffText Text to compare to the active editor document text
-   * @param activeEditor The active editor to compare to the diff text
-   */
-  async function displayDiff(
-    diffText: string | undefined,
-    activeEditor: vscode.TextEditor,
-  ) {
-    const tempFile = await vscode.workspace.openTextDocument({
-      content: diffText ?? "",
-      language: activeEditor.document.languageId,
-    });
-
-    vscode.commands.executeCommand(
-      "vscode.diff",
-      activeEditor.document.uri,
-      tempFile.uri,
-    );
-  }
-
-  /**
-   * Gets a completion from the model given code and instructions, and handles the response.
-   * Checks for input/response errors along the way. Handles a failed completion response.
-   *
-   * @param code The code to act on in the completion model
-   * @param instruction The instructions for the completion model
-   * @param handleResponse The function to handle a successful response from the completion model
-   */
-  function getCompletion(
-    code: string | undefined,
-    instruction: string,
-    progressTitle: string,
-    handleResponse: (
-      completion: CompletionModelResponse,
-      activeEditor: vscode.TextEditor,
-    ) => void,
-  ) {
-    const activeEditor = vscode.window.activeTextEditor;
-    if (!activeEditor) {
-      vscode.window.showErrorMessage("No active editor");
-      return;
-    }
-    if (!code) {
-      vscode.window.showErrorMessage("No input code");
-      return;
-    }
-
-    let completion: CompletionModelResponse | undefined;
-    vscode.window
-      .withProgress(
-        {
-          location: vscode.ProgressLocation.Notification,
-          cancellable: false, // TODO: make this cancellable (or have a configurable timeout or something)
-          title: progressTitle,
-        },
-        async () => {
-          completion = await completionModel.complete({
-            instruction: instruction,
-            code: code,
-          });
-        },
-      )
-      .then(async () => {
-        if (completion && completion.success && completion.completion) {
-          handleResponse(completion, activeEditor);
-          return;
-        }
-        if (!completion) {
-          vscode.window.showErrorMessage("No response from completion model");
-        } else {
-          vscode.window.showErrorMessage(
-            completion?.errorMessage ||
-              "Unknown error occurred while getting completion",
-          );
-        }
-      });
-  }
+  const reviewFileCodeCommand = getReviewFileCodeCommand(completionModel);
+  const reviewSelectedCodeCommand =
+    getReviewSelectedCodeCommand(completionModel);
 
   // Add the commands to the extension context so they can be used
   context.subscriptions.push(reviewFileCodeCommand);
   context.subscriptions.push(reviewSelectedCodeCommand);
 }
 
-// This method is called when your extension is deactivated
+// This method is called when the extension is deactivated
 export function deactivate() {}

--- a/src/helpers/displayDiff.ts
+++ b/src/helpers/displayDiff.ts
@@ -1,0 +1,23 @@
+import * as vscode from "vscode";
+
+/**
+ * Displays a diff comparison of the active editor document and the provided content in a new editor.
+ *
+ * @param diffText Text to compare to the active editor document text
+ * @param activeEditor The active editor to compare to the diff text
+ */
+export async function displayDiff(
+  diffText: string | undefined,
+  activeEditor: vscode.TextEditor,
+) {
+  const tempFile = await vscode.workspace.openTextDocument({
+    content: diffText ?? "",
+    language: activeEditor.document.languageId,
+  });
+
+  vscode.commands.executeCommand(
+    "vscode.diff",
+    activeEditor.document.uri,
+    tempFile.uri,
+  );
+}

--- a/src/helpers/doCompletion.ts
+++ b/src/helpers/doCompletion.ts
@@ -1,0 +1,64 @@
+import * as vscode from "vscode";
+import {
+  CompletionModel,
+  CompletionModelResponse,
+} from "../CompletionModel/CompletionModel";
+
+/**
+ * Gets a completion from the model given code and instructions, and handles the response.
+ * Checks for input/response errors along the way. Handles a failed completion response.
+ *
+ * @param code The code to act on in the completion model
+ * @param instruction The instructions for the completion model
+ * @param handleResponse The function to handle a successful response from the completion model
+ */
+export function doCompletion(
+  completionModel: CompletionModel,
+  code: string | undefined,
+  instruction: string,
+  progressTitle: string,
+  handleResponse: (
+    completion: CompletionModelResponse,
+    activeEditor: vscode.TextEditor,
+  ) => void,
+) {
+  const activeEditor = vscode.window.activeTextEditor;
+  if (!activeEditor) {
+    vscode.window.showErrorMessage("No active editor");
+    return;
+  }
+  if (!code) {
+    vscode.window.showErrorMessage("No input code");
+    return;
+  }
+
+  let completion: CompletionModelResponse | undefined;
+  vscode.window
+    .withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        cancellable: false, // TODO: make this cancellable (or have a configurable timeout or something)
+        title: progressTitle,
+      },
+      async () => {
+        completion = await completionModel.complete({
+          instruction: instruction,
+          code: code,
+        });
+      },
+    )
+    .then(async () => {
+      if (completion && completion.success && completion.completion) {
+        handleResponse(completion, activeEditor);
+        return;
+      }
+      if (!completion) {
+        vscode.window.showErrorMessage("No response from completion model");
+      } else {
+        vscode.window.showErrorMessage(
+          completion?.errorMessage ||
+            "Unknown error occurred while getting completion",
+        );
+      }
+    });
+}

--- a/src/helpers/getDocumentTextAfterSelection.ts
+++ b/src/helpers/getDocumentTextAfterSelection.ts
@@ -1,0 +1,17 @@
+import * as vscode from "vscode";
+
+export const getDocumentTextAfterSelection = (
+  activeEditor: vscode.TextEditor,
+): string => {
+  return activeEditor.document.getText(
+    new vscode.Range(
+      activeEditor.selection.end,
+      new vscode.Position(
+        activeEditor.document.lineCount - 1,
+        activeEditor.document.lineAt(
+          activeEditor.document.lineCount - 1,
+        ).text.length,
+      ),
+    ),
+  );
+};

--- a/src/helpers/getDocumentTextBeforeSelection.ts
+++ b/src/helpers/getDocumentTextBeforeSelection.ts
@@ -1,0 +1,9 @@
+import * as vscode from "vscode";
+
+export const getDocumentTextBeforeSelection = (
+  activeEditor: vscode.TextEditor,
+): string => {
+  return activeEditor.document.getText(
+    new vscode.Range(new vscode.Position(0, 0), activeEditor.selection.start),
+  );
+};

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,0 +1,5 @@
+export { displayDiff } from "./displayDiff";
+export { doCompletion } from "./doCompletion";
+export { getDocumentTextAfterSelection } from "./getDocumentTextAfterSelection";
+export { getDocumentTextBeforeSelection } from "./getDocumentTextBeforeSelection";
+export { injectCompletionModel } from "./injectCompletionModel";


### PR DESCRIPTION
This refactors code out of `src/extension.ts`. Commands will now be put into `./commands`. The code common between commands was moved into `./helpers`.