### PR TITLE
Add handler for when the settings for the extension changes.

### DIFF
--- a/src/CompletionModel/CompletionModelProvider.ts
+++ b/src/CompletionModel/CompletionModelProvider.ts
@@ -1,0 +1,17 @@
+import { CompletionModel } from "./CompletionModel";
+
+export class CompletionModelProvider {
+  private _completionModel: CompletionModel;
+
+  constructor(completionModel: CompletionModel) {
+    this._completionModel = completionModel;
+  }
+
+  getCompletionModel(): CompletionModel {
+    return this._completionModel;
+  }
+
+  setCompletionModel(completionModel: CompletionModel) {
+    this._completionModel = completionModel;
+  }
+}

--- a/src/CompletionModel/Implementations/PaLMCompletionModel.ts
+++ b/src/CompletionModel/Implementations/PaLMCompletionModel.ts
@@ -10,7 +10,6 @@ export class PaLMCompletionModel implements CompletionModel {
   private client: TextServiceClient;
 
   constructor(apiKey: string) {
-    console.log(apiKey);
     this.client = new TextServiceClient({
       authClient: new GoogleAuth().fromAPIKey(apiKey),
     });
@@ -29,7 +28,6 @@ export class PaLMCompletionModel implements CompletionModel {
         text: this.formatPrompt(request),
       },
     });
-    console.log(completion);
 
     if (
       completion[0] &&

--- a/src/commands/getReviewFileCodeCommand.ts
+++ b/src/commands/getReviewFileCodeCommand.ts
@@ -4,14 +4,14 @@ import {
   CODE_REVIEW_PROGRESS_TITLE,
 } from "./constants";
 import { doCompletion, displayDiff } from "../helpers";
-import { CompletionModel } from "../CompletionModel/CompletionModel";
+import { CompletionModelProvider } from "../CompletionModel/CompletionModelProvider";
 
 /**
  * Queries the model for a reviewed, edited version of the current file contents.
  * Displays a diff of the active editor document and the completion response.
  */
 export const getReviewFileCodeCommand = (
-  completionModel: CompletionModel,
+  completionModelProvider: CompletionModelProvider,
 ): vscode.Disposable => {
   const reviewFileCodeCommand = vscode.commands.registerCommand(
     "vs-code-ai-extension.reviewFileCode",
@@ -21,7 +21,7 @@ export const getReviewFileCodeCommand = (
       const progressTitle = CODE_REVIEW_PROGRESS_TITLE;
 
       doCompletion(
-        completionModel,
+        completionModelProvider.getCompletionModel(),
         code,
         modelInstruction,
         progressTitle,

--- a/src/commands/getReviewSelectedCodeCommand.ts
+++ b/src/commands/getReviewSelectedCodeCommand.ts
@@ -9,14 +9,14 @@ import {
   CODE_REVIEW_INSTRUCTION,
   CODE_REVIEW_PROGRESS_TITLE,
 } from "./constants";
-import { CompletionModel } from "../CompletionModel/CompletionModel";
+import { CompletionModelProvider } from "../CompletionModel/CompletionModelProvider";
 
 /**
  * Queries the model for a reviewed, edited version of the currently selected code.
  * Displays a diff of the active editor document and the completion response in context of the overall file.
  */
 export const getReviewSelectedCodeCommand = (
-  completionModel: CompletionModel,
+  completionModelProvider: CompletionModelProvider,
 ): vscode.Disposable => {
   return vscode.commands.registerCommand(
     "vs-code-ai-extension.reviewSelectedCode",
@@ -28,7 +28,7 @@ export const getReviewSelectedCodeCommand = (
       const progressTitle = CODE_REVIEW_PROGRESS_TITLE;
 
       doCompletion(
-        completionModel,
+        completionModelProvider.getCompletionModel(),
         code,
         modelInstruction,
         progressTitle,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,8 @@ import * as vscode from "vscode";
 import { injectCompletionModel } from "./helpers";
 import { getReviewFileCodeCommand } from "./commands/getReviewFileCodeCommand";
 import { getReviewSelectedCodeCommand } from "./commands/getReviewSelectedCodeCommand";
+import { CompletionModelProvider } from "./CompletionModel/CompletionModelProvider";
+import { getOnDidChangeConfigurationHandler } from "./helpers/getOnDidChangeConfigurationHandler";
 
 // This method is called when the extension is activated
 // The extension is activated the very first time the command is executed
@@ -10,21 +12,30 @@ export function activate(context: vscode.ExtensionContext) {
     'Congratulations, your extension "vs-code-ai-extension" is now active!',
   );
 
-  // There should be an event handler added for onDidChangeConfiguration to handle the case
-  // where the user changes the model or API key while the extension is running.
-  const completionModel = injectCompletionModel();
+  const completionModelProvider = new CompletionModelProvider(
+    injectCompletionModel(),
+  );
 
   // For commands that have been defined in the package.json file,
   // provide the implementation with registerCommand.
   // The commandId parameter must match the command field in package.json
 
-  const reviewFileCodeCommand = getReviewFileCodeCommand(completionModel);
-  const reviewSelectedCodeCommand =
-    getReviewSelectedCodeCommand(completionModel);
+  const reviewFileCodeCommand = getReviewFileCodeCommand(
+    completionModelProvider,
+  );
+  const reviewSelectedCodeCommand = getReviewSelectedCodeCommand(
+    completionModelProvider,
+  );
+  const onDidChangeConfigurationHandler = getOnDidChangeConfigurationHandler(
+    completionModelProvider,
+  );
 
-  // Add the commands to the extension context so they can be used
-  context.subscriptions.push(reviewFileCodeCommand);
-  context.subscriptions.push(reviewSelectedCodeCommand);
+  // Add the commands and event handlers to the extension context so they can be used
+  context.subscriptions.push(
+    reviewFileCodeCommand,
+    reviewSelectedCodeCommand,
+    onDidChangeConfigurationHandler,
+  );
 }
 
 // This method is called when the extension is deactivated

--- a/src/helpers/getOnDidChangeConfigurationHandler.ts
+++ b/src/helpers/getOnDidChangeConfigurationHandler.ts
@@ -1,0 +1,16 @@
+import * as vscode from "vscode";
+import { CompletionModelProvider } from "../CompletionModel/CompletionModelProvider";
+import { injectCompletionModel } from "./injectCompletionModel";
+
+export const getOnDidChangeConfigurationHandler = (
+  completionModelProvider: CompletionModelProvider,
+): vscode.Disposable => {
+  return vscode.workspace.onDidChangeConfiguration((event) => {
+    if (
+      event.affectsConfiguration("vs-code-ai-extension.model") ||
+      event.affectsConfiguration("vs-code-ai-extension.APIKey")
+    ) {
+      completionModelProvider.setCompletionModel(injectCompletionModel());
+    }
+  });
+};

--- a/src/helpers/injectCompletionModel.ts
+++ b/src/helpers/injectCompletionModel.ts
@@ -2,24 +2,10 @@ import { CompletionModel } from "../CompletionModel/CompletionModel";
 import { GPTCompletionModel } from "../CompletionModel/Implementations/GPTCompletionModel";
 import { UnsetCompletionModel } from "../CompletionModel/Implementations/UnsetCompletionModel";
 import * as vscode from "vscode";
-import { CompletionModelType, MessageSeverity } from "./types";
+import { CompletionModelType } from "./types";
 import { PaLMCompletionModel } from "../CompletionModel/Implementations/PaLMCompletionModel";
 
-const injectUnsetCompletionModel = (
-  message: string,
-  severity: MessageSeverity,
-): UnsetCompletionModel => {
-  switch (severity) {
-    case MessageSeverity.Error:
-      vscode.window.showErrorMessage(message);
-      break;
-    case MessageSeverity.Warning:
-      vscode.window.showWarningMessage(message);
-      break;
-    case MessageSeverity.Info:
-      vscode.window.showInformationMessage(message);
-      break;
-  }
+const injectUnsetCompletionModel = (message: string): UnsetCompletionModel => {
   return new UnsetCompletionModel(message);
 };
 
@@ -31,10 +17,7 @@ const injectGPTCompletionModel = ():
 
   if (apiKey) return new GPTCompletionModel(apiKey);
 
-  return injectUnsetCompletionModel(
-    "vs-code-ai-extension: APIKey not set",
-    MessageSeverity.Warning,
-  );
+  return injectUnsetCompletionModel("vs-code-ai-extension: APIKey not set");
 };
 
 const injectPaLMCompletionModel = ():
@@ -45,10 +28,7 @@ const injectPaLMCompletionModel = ():
 
   if (apiKey) return new PaLMCompletionModel(apiKey);
 
-  return injectUnsetCompletionModel(
-    "vs-code-ai-extension: APIKey not set",
-    MessageSeverity.Warning,
-  );
+  return injectUnsetCompletionModel("vs-code-ai-extension: APIKey not set");
 };
 
 export const injectCompletionModel = (): CompletionModel => {
@@ -61,9 +41,6 @@ export const injectCompletionModel = (): CompletionModel => {
     case CompletionModelType.PaLM:
       return injectPaLMCompletionModel();
     default:
-      return injectUnsetCompletionModel(
-        "vs-code-ai-extension: Model not set",
-        MessageSeverity.Warning,
-      );
+      return injectUnsetCompletionModel("vs-code-ai-extension: Model not set");
   }
 };


### PR DESCRIPTION
- Use CompletionModelProvider to support changing out completion models.
- Remove the message from injectCompletionModel to avoid showing too many duplicate messages.
- Add the on configuration change handler.

### QA Steps

1. Checkout branch.
2. Run extension.
3. Remove the API key in settings.
4. Run one of the review code commands.
5. An error message should show saying that the API key is not set.
6. Replace the API key.
7. Run one of the review code commands.
8. The command should run as normal.