### PR TITLE
Basic "Apply proposed changes" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,13 +46,18 @@
         "command": "vs-code-ai-extension.reviewSelectedCode",
         "title": "Review Selected Code",
         "category": "AI Extension"
+      },
+      {
+        "command": "vs-code-ai-extension.applyProposedChanges",
+        "title": "Apply Proposed Changes",
+        "category": "AI Extension"
       }
     ],
     "menus": {
       "commandPalette": [
         {
           "command": "vs-code-ai-extension.reviewFileCode",
-          "when": "editorFocus && !editorReadonly && !isInDiffEditor"
+          "when": "!editorReadonly && !isInDiffEditor"
         },
         {
           "command": "vs-code-ai-extension.reviewSelectedCode",
@@ -76,6 +81,11 @@
           "when": "editorFocus && !editorReadonly && !isInDiffEditor",
           "command": "vs-code-ai-extension.reviewFileCode",
           "group": "navigation@1"
+        },
+        {
+          "command": "vs-code-ai-extension.applyProposedChanges",
+          "group": "navigation",
+          "when": "resourceScheme == ai-code-review"
         }
       ]
     }

--- a/src/commands/getApplyProposedChangesCommand.ts
+++ b/src/commands/getApplyProposedChangesCommand.ts
@@ -1,0 +1,39 @@
+import * as vscode from "vscode";
+import { TextProviderScheme } from "../helpers/types";
+
+/**
+ * Applies the proposed changes to the actual (not virtual) file with the same paths
+ * the active editor document (which should be part of the diff comparison).
+ * Closes the active editor and opens the updated file.
+ * Does not save the file after changes are applied.
+ */
+export const getApplyProposedChangesCommand = (): vscode.Disposable => {
+  return vscode.commands.registerCommand(
+    "vs-code-ai-extension.applyProposedChanges",
+    async () => {
+      if (!vscode.window.activeTextEditor) {
+        return;
+      }
+      const { document } = vscode.window.activeTextEditor;
+      if (document.uri.scheme != TextProviderScheme.AiCodeReview) {
+        return;
+      }
+
+      // The document.uri.path doesn't include the code review scheme and is thus the uri the actual file path we want to edit.
+      // This is dependent on how the uri was established when opening said file in the first place.
+      const uriToUpdate = vscode.Uri.file(document.uri.path);
+      const edit = new vscode.WorkspaceEdit();
+      edit.replace(
+        uriToUpdate,
+        new vscode.Range(0, 0, document.lineCount, 0),
+        document.getText(),
+      );
+      await vscode.workspace.applyEdit(edit);
+
+      await vscode.commands.executeCommand(
+        "workbench.action.closeActiveEditor",
+      );
+      await vscode.window.showTextDocument(uriToUpdate);
+    },
+  );
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,8 @@ import { getReviewFileCodeCommand } from "./commands/getReviewFileCodeCommand";
 import { getReviewSelectedCodeCommand } from "./commands/getReviewSelectedCodeCommand";
 import { CompletionModelProvider } from "./CompletionModel/CompletionModelProvider";
 import { getOnDidChangeConfigurationHandler } from "./helpers/getOnDidChangeConfigurationHandler";
+import { getReviewCodeTextDocumentContentProvider } from "./helpers/getReviewCodeTextDocumentContentProvider";
+import { getApplyProposedChangesCommand } from "./commands/getApplyProposedChangesCommand";
 
 // This method is called when the extension is activated
 // The extension is activated the very first time the command is executed
@@ -26,15 +28,20 @@ export function activate(context: vscode.ExtensionContext) {
   const reviewSelectedCodeCommand = getReviewSelectedCodeCommand(
     completionModelProvider,
   );
+  const applyProposedChangesCommand = getApplyProposedChangesCommand();
   const onDidChangeConfigurationHandler = getOnDidChangeConfigurationHandler(
     completionModelProvider,
   );
+  const reviewCodeTextDocumentContentProvider =
+    getReviewCodeTextDocumentContentProvider();
 
   // Add the commands and event handlers to the extension context so they can be used
   context.subscriptions.push(
     reviewFileCodeCommand,
     reviewSelectedCodeCommand,
+    applyProposedChangesCommand,
     onDidChangeConfigurationHandler,
+    reviewCodeTextDocumentContentProvider,
   );
 }
 

--- a/src/helpers/doCompletion.ts
+++ b/src/helpers/doCompletion.ts
@@ -7,6 +7,7 @@ import {
 /**
  * Gets a completion from the model given code and instructions, and handles the response.
  * Checks for input/response errors along the way. Handles a failed completion response.
+ * Displays a progress bar notification while waiting for the response.
  *
  * @param code The code to act on in the completion model
  * @param instruction The instructions for the completion model

--- a/src/helpers/getReviewCodeTextDocumentContentProvider.ts
+++ b/src/helpers/getReviewCodeTextDocumentContentProvider.ts
@@ -1,0 +1,20 @@
+import * as vscode from "vscode";
+import { TextProviderScheme } from "./types";
+
+/**
+ * Using the defined code review scheme, returns a disposable object that can be used to register a text document content provider.
+ * This TextDocumentContentProvider returns an empty file, as the caller must then provide its contents.
+ *
+ * @returns An object that can be used to register a text document content provider for the defined code review scheme.
+ */
+export const getReviewCodeTextDocumentContentProvider =
+  (): vscode.Disposable => {
+    return vscode.workspace.registerTextDocumentContentProvider(
+      TextProviderScheme.AiCodeReview,
+      new (class implements vscode.TextDocumentContentProvider {
+        provideTextDocumentContent(): string {
+          return "";
+        }
+      })(),
+    );
+  };

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -3,6 +3,10 @@ export enum CompletionModelType {
   PaLM = "text-bison-001",
 }
 
+export enum TextProviderScheme {
+  AiCodeReview = "ai-code-review",
+}
+
 export enum MessageSeverity {
   Error = "error",
   Warning = "warning",


### PR DESCRIPTION
Includes adding a TextDocumentContentProvider for read-only view
Command only usable from diff comparison of code review suggestions

Again, not committed to any of the naming. Could be "Apply suggestions" or something like that instead.

This feature is a simpler version of #35 

Closes #25 