### PR TITLE
Add user-input prompt template wrapper

### DIFF
--- a/src/commands/constants.ts
+++ b/src/commands/constants.ts
@@ -8,3 +8,6 @@ export const PROMPT_FOR_USER_PROMPT =
   "Enter a request for the AI's review of the code.";
 export const INVALID_USER_INPUT_ERROR_MESSAGE =
   "No input provided. Cannot query model.";
+export const CUSTOM_PROMPT_TEMPLATE_PREFIX =
+  "You are a coding assistant. Return only the modified code. Avoid returning any code fences or additional explanations. Your primary task: ";
+export const CUSTOM_PROMPT_TEMPLATE_SUFFIX = "\nCode to review:\n";

--- a/src/commands/getReviewFileCodeCustomPromptCommand.ts
+++ b/src/commands/getReviewFileCodeCustomPromptCommand.ts
@@ -1,6 +1,8 @@
 import * as vscode from "vscode";
 import {
   CODE_REVIEW_PROGRESS_TITLE,
+  CUSTOM_PROMPT_TEMPLATE_PREFIX,
+  CUSTOM_PROMPT_TEMPLATE_SUFFIX,
   INVALID_USER_INPUT_ERROR_MESSAGE,
 } from "./constants";
 import { doCompletion, displayDiff, getUserPrompt } from "../helpers";
@@ -17,7 +19,10 @@ export const getReviewFileCodeCustomPromptCommand = (
     "vs-code-ai-extension.reviewFileCodeCustomPrompt",
     async () => {
       const code = vscode.window.activeTextEditor?.document.getText();
-      const modelInstruction = await getUserPrompt();
+      const modelInstruction =
+        CUSTOM_PROMPT_TEMPLATE_PREFIX +
+        (await getUserPrompt()) +
+        CUSTOM_PROMPT_TEMPLATE_SUFFIX;
       const progressTitle = CODE_REVIEW_PROGRESS_TITLE;
 
       if (!modelInstruction) {

--- a/src/commands/getReviewSelectedCodeCustomPromptCommand.ts
+++ b/src/commands/getReviewSelectedCodeCustomPromptCommand.ts
@@ -8,6 +8,8 @@ import {
 } from "../helpers";
 import {
   CODE_REVIEW_PROGRESS_TITLE,
+  CUSTOM_PROMPT_TEMPLATE_PREFIX,
+  CUSTOM_PROMPT_TEMPLATE_SUFFIX,
   INVALID_USER_INPUT_ERROR_MESSAGE,
 } from "./constants";
 import { SettingsProvider } from "../helpers/SettingsProvider";
@@ -26,7 +28,10 @@ export const getReviewSelectedCodeCustomPromptCommand = (
         vscode.window.activeTextEditor?.selection,
       );
 
-      const modelInstruction = await getUserPrompt();
+      const modelInstruction =
+        CUSTOM_PROMPT_TEMPLATE_PREFIX +
+        (await getUserPrompt()) +
+        CUSTOM_PROMPT_TEMPLATE_SUFFIX;
       const progressTitle = CODE_REVIEW_PROGRESS_TITLE;
 
       if (!modelInstruction) {

--- a/src/helpers/displayDiff.ts
+++ b/src/helpers/displayDiff.ts
@@ -18,7 +18,14 @@ export async function displayDiff(
   );
   const doc = await vscode.workspace.openTextDocument(uri); // calls back into the custom TextDocumentContentProvider for the scheme
   const edit = new vscode.WorkspaceEdit();
-  edit.insert(uri, new vscode.Position(0, 0), diffText ?? "");
+  edit.replace(
+    uri,
+    new vscode.Range(
+      new vscode.Position(0, 0),
+      doc.lineAt(doc.lineCount - 1).range.end,
+    ),
+    diffText ?? "",
+  );
   await vscode.workspace.applyEdit(edit);
 
   vscode.commands.executeCommand(


### PR DESCRIPTION
- Fixed bug where the diff editor displayed too much text
- Switched user-input prompts to use a template wrapper

Closes #50 