### PR TITLE
Byolad settings overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-All notable changes to the "vs-code-ai-extension" extension will be documented in this file.
+All notable changes to the "vscode-byolad" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "vs-code-ai-extension",
+  "name": "vscode-byolad",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vs-code-ai-extension",
+      "name": "vscode-byolad",
       "version": "0.0.1",
       "dependencies": {
         "@google-ai/generativelanguage": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,18 @@
 {
-  "publisher": "vs-code-ai-extension",
-  "name": "vs-code-ai-extension",
-  "displayName": "vs-code-ai-extension",
+  "publisher": "BeanLab",
+  "name": "vscode-byolad",
+  "displayName": "byoLAD",
   "description": "",
   "version": "0.0.1",
   "engines": {
     "vscode": "^1.81.0"
   },
+  "license": "SEE LICENSE IN LICENSE",
   "categories": [
-    "Other"
+    "Programming Languages",
+    "Snippets",
+    "Machine Learning",
+    "Education"
   ],
   "activationEvents": [],
   "main": "./out/extension.js",
@@ -16,45 +20,47 @@
     "configuration": {
       "title": "byoLAD",
       "properties": {
-        "vs-code-ai-extension.provider": {
+        "vscode-byolad.provider": {
           "type": "string",
           "enum": [
             "OpenAI",
             "Google"
           ],
           "default": "OpenAI",
-          "description": "The provider to use for AI completion",
+          "markdownDescription": "The provider to use for AI completion\n\nYou are billed by the provider for AI completion according to their policies.",
           "order": 0
         },
-        "vs-code-ai-extension.model": {
+        "vscode-byolad.model": {
           "type": "string",
           "default": "",
-          "description": "The model to use for AI completion",
+          "markdownDescription": "The model to use for AI completion\n\nFor OpenAI, format your input like 'gpt-4-32k' or 'gpt-3.5-turbo'. See all available models [here](https://platform.openai.com/docs/models/).\n\nFor Google, format your input like 'text-bison-001' or 'chat-bison-001'. See all available models [here](https://developers.generativeai.google/models/language).",
           "order": 1
         },
-        "vs-code-ai-extension.APIKey": {
+        "vscode-byolad.APIKey": {
           "type": "string",
           "default": "",
-          "description": "The API key to use for AI completion",
+          "markdownDescription": "The API key to use for AI completion\n\nGet an API key for OpenAI [here](https://platform.openai.com/account/api-keys). Get an API key for Google [here](https://developers.generativeai.google/tutorials/setup).",
           "order": 2
         },
-        "vs-code-ai-extension.reviewFileCodePrompt": {
+        "vscode-byolad.reviewFileCodePrompt": {
           "type": "string",
           "default": "You are acting as GitHub Copilot. Return only code. Review the code and fix any bugs, then return the code.",
           "description": "The prompt to use when reviewing a file",
+          "editPresentation": "multilineText",
           "order": 3
         },
-        "vs-code-ai-extension.reviewSelectedCodePrompt": {
+        "vscode-byolad.reviewSelectedCodePrompt": {
           "type": "string",
           "default": "You are acting as GitHub Copilot. Return only code. Review the code and fix any bugs, then return the code.",
           "description": "The prompt to use when reviewing selected code",
+          "editPresentation": "multilineText",
           "order": 4
         }
       }
     },
     "commands": [
       {
-        "command": "vs-code-ai-extension.reviewFileCode",
+        "command": "vscode-byolad.reviewFileCode",
         "title": "byoLAD — Review Code File",
         "category": "byoLAD",
         "icon": {
@@ -63,7 +69,7 @@
         }
       },
       {
-        "command": "vs-code-ai-extension.reviewSelectedCode",
+        "command": "vscode-byolad.reviewSelectedCode",
         "title": "byoLAD — Review Selected Code",
         "category": "byoLAD",
         "icon": {
@@ -72,7 +78,7 @@
         }
       },
       {
-        "command": "vs-code-ai-extension.reviewFileCodeCustomPrompt",
+        "command": "vscode-byolad.reviewFileCodeCustomPrompt",
         "title": "byoLAD — Review Code File (Custom Prompt)",
         "category": "byoLAD",
         "icon": {
@@ -81,7 +87,7 @@
         }
       },
       {
-        "command": "vs-code-ai-extension.reviewSelectedCodeCustomPrompt",
+        "command": "vscode-byolad.reviewSelectedCodeCustomPrompt",
         "title": "byoLAD — Review Selected Code (Custom Prompt)",
         "category": "byoLAD",
         "icon": {
@@ -90,7 +96,7 @@
         }
       },
       {
-        "command": "vs-code-ai-extension.applyProposedChanges",
+        "command": "vscode-byolad.applyProposedChanges",
         "title": "Apply Proposed Changes",
         "category": "byoLAD"
       }
@@ -98,57 +104,57 @@
     "menus": {
       "commandPalette": [
         {
-          "command": "vs-code-ai-extension.reviewFileCode",
+          "command": "vscode-byolad.reviewFileCode",
           "when": "!editorReadonly && !isInDiffEditor"
         },
         {
-          "command": "vs-code-ai-extension.reviewSelectedCode",
+          "command": "vscode-byolad.reviewSelectedCode",
           "when": "editorHasSelection && !editorReadonly && !isInDiffEditor && !editorHasMultipleSelections"
         },
         {
-          "command": "vs-code-ai-extension.reviewFileCodeCustomPrompt",
+          "command": "vscode-byolad.reviewFileCodeCustomPrompt",
           "when": "!editorReadonly && !isInDiffEditor"
         },
         {
-          "command": "vs-code-ai-extension.reviewSelectedCodeCustomPrompt",
+          "command": "vscode-byolad.reviewSelectedCodeCustomPrompt",
           "when": "editorHasSelection && !editorReadonly && !isInDiffEditor"
         }
       ],
       "editor/context": [
         {
           "when": "!editorHasSelection && editorFocus && !editorReadonly && !isInDiffEditor",
-          "command": "vs-code-ai-extension.reviewFileCode",
+          "command": "vscode-byolad.reviewFileCode",
           "group": "1_modification"
         },
         {
           "when": "editorHasSelection && !editorReadonly && !isInDiffEditor && !editorHasMultipleSelections",
-          "command": "vs-code-ai-extension.reviewSelectedCode",
+          "command": "vscode-byolad.reviewSelectedCode",
           "group": "1_modification"
         },
         {
           "when": "!editorHasSelection && editorFocus && !editorReadonly && !isInDiffEditor",
-          "command": "vs-code-ai-extension.reviewFileCodeCustomPrompt",
+          "command": "vscode-byolad.reviewFileCodeCustomPrompt",
           "group": "1_modification"
         },
         {
           "when": "editorHasSelection && !editorReadonly && !isInDiffEditor && !editorHasMultipleSelections",
-          "command": "vs-code-ai-extension.reviewSelectedCodeCustomPrompt",
+          "command": "vscode-byolad.reviewSelectedCodeCustomPrompt",
           "group": "1_modification"
         }
       ],
       "editor/title": [
         {
           "when": "!editorHasSelection && !editorReadonly && !isInDiffEditor",
-          "command": "vs-code-ai-extension.reviewFileCode",
+          "command": "vscode-byolad.reviewFileCode",
           "group": "navigation@1"
         },
         {
           "when": "editorHasSelection && !editorReadonly && !isInDiffEditor",
-          "command": "vs-code-ai-extension.reviewSelectedCode",
+          "command": "vscode-byolad.reviewSelectedCode",
           "group": "navigation@1"
         },
         {
-          "command": "vs-code-ai-extension.applyProposedChanges",
+          "command": "vscode-byolad.applyProposedChanges",
           "group": "navigation",
           "when": "resourceScheme == ai-code-review"
         }

--- a/package.json
+++ b/package.json
@@ -3,18 +3,32 @@
   "name": "vscode-byolad",
   "displayName": "byoLAD",
   "description": "",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "engines": {
     "vscode": "^1.81.0"
   },
   "license": "SEE LICENSE IN LICENSE",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/beanlab/vs-code-ai-extension.git"
+  },
+  "bugs": {
+    "url": "https://github.com/beanlab/vs-code-ai-extension/issues"
+  },
   "categories": [
     "Programming Languages",
     "Snippets",
     "Machine Learning",
     "Education"
   ],
+  "keywords": [
+    "ai",
+    "assistant",
+    "code review"
+  ],
   "activationEvents": [],
+  "preview": true,
+  "icon": "byo_LAD.png",
   "main": "./out/extension.js",
   "contributes": {
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -27,19 +27,19 @@
             "Google"
           ],
           "default": "OpenAI",
-          "markdownDescription": "The provider to use for AI completion\n\nYou are billed by the provider for AI completion according to their policies.",
+          "markdownDescription": "You are billed by the provider according to their API usage policies.",
           "order": 0
         },
         "vscode-byolad.model": {
           "type": "string",
           "default": "",
-          "markdownDescription": "The model to use for AI completion\n\nFor OpenAI, format your input like 'gpt-4-32k' or 'gpt-3.5-turbo'. See all available models [here](https://platform.openai.com/docs/models/).\n\nFor Google, format your input like 'text-bison-001' or 'chat-bison-001'. See all available models [here](https://developers.generativeai.google/models/language).",
+          "markdownDescription": "For OpenAI, format your input like 'gpt-4-32k' or 'gpt-3.5-turbo'. See all available models [here](https://platform.openai.com/docs/models/).\n\nFor Google, format your input like 'text-bison-001' or 'chat-bison-001'. See all available models [here](https://developers.generativeai.google/models/language).",
           "order": 1
         },
         "vscode-byolad.APIKey": {
           "type": "string",
           "default": "",
-          "markdownDescription": "The API key to use for AI completion\n\nGet an API key for OpenAI [here](https://platform.openai.com/account/api-keys). Get an API key for Google [here](https://developers.generativeai.google/tutorials/setup).",
+          "markdownDescription": "Get an API key for OpenAI [here](https://platform.openai.com/account/api-keys).\n\nGet an API key for Google [here](https://developers.generativeai.google/tutorials/setup).",
           "order": 2
         },
         "vscode-byolad.reviewFileCodePrompt": {

--- a/src/CompletionModel/Implementations/GPTCompletionModel.ts
+++ b/src/CompletionModel/Implementations/GPTCompletionModel.ts
@@ -40,13 +40,13 @@ export class GPTCompletionModel implements CompletionModel {
         return {
           success: false,
           errorMessage:
-            "vs-code-ai-extension: There was no completion provided by the model.",
+            "vscode-byolad: There was no completion provided by the model.",
         };
       })
       .catch((error) => {
         return {
           success: false,
-          errorMessage: `vs-code-ai-extension: ${error.message}`,
+          errorMessage: `vscode-byolad: ${error.message}`,
         };
       });
   }

--- a/src/CompletionModel/Implementations/PaLMCompletionModel.ts
+++ b/src/CompletionModel/Implementations/PaLMCompletionModel.ts
@@ -45,13 +45,13 @@ export class PaLMCompletionModel implements CompletionModel {
         return {
           success: false,
           errorMessage:
-            "vs-code-ai-extension: There was no completion provided by the model.",
+            "vscode-byolad: There was no completion provided by the model.",
         };
       })
       .catch((error) => {
         return {
           success: false,
-          errorMessage: `vs-code-ai-extension: ${error.message}`,
+          errorMessage: `vscode-byolad: ${error.message}`,
         };
       });
   }

--- a/src/commands/getApplyProposedChangesCommand.ts
+++ b/src/commands/getApplyProposedChangesCommand.ts
@@ -9,7 +9,7 @@ import { TextProviderScheme } from "../helpers/types";
  */
 export const getApplyProposedChangesCommand = (): vscode.Disposable => {
   return vscode.commands.registerCommand(
-    "vs-code-ai-extension.applyProposedChanges",
+    "vscode-byolad.applyProposedChanges",
     async () => {
       if (!vscode.window.activeTextEditor) {
         return;

--- a/src/commands/getReviewFileCodeCommand.ts
+++ b/src/commands/getReviewFileCodeCommand.ts
@@ -14,7 +14,7 @@ export const getReviewFileCodeCommand = (
   settingsProvider: SettingsProvider,
 ): vscode.Disposable => {
   const reviewFileCodeCommand = vscode.commands.registerCommand(
-    "vs-code-ai-extension.reviewFileCode",
+    "vscode-byolad.reviewFileCode",
     async () => {
       const code = vscode.window.activeTextEditor?.document.getText();
       const modelInstruction =

--- a/src/commands/getReviewFileCodeCustomPromptCommand.ts
+++ b/src/commands/getReviewFileCodeCustomPromptCommand.ts
@@ -14,7 +14,7 @@ export const getReviewFileCodeCustomPromptCommand = (
   settingsProvider: SettingsProvider,
 ): vscode.Disposable => {
   const reviewFileCodeCommand = vscode.commands.registerCommand(
-    "vs-code-ai-extension.reviewFileCodeCustomPrompt",
+    "vscode-byolad.reviewFileCodeCustomPrompt",
     async () => {
       const code = vscode.window.activeTextEditor?.document.getText();
       const modelInstruction = await getUserPrompt();

--- a/src/commands/getReviewSelectedCodeCommand.ts
+++ b/src/commands/getReviewSelectedCodeCommand.ts
@@ -19,7 +19,7 @@ export const getReviewSelectedCodeCommand = (
   settingsProvider: SettingsProvider,
 ): vscode.Disposable => {
   return vscode.commands.registerCommand(
-    "vs-code-ai-extension.reviewSelectedCode",
+    "vscode-byolad.reviewSelectedCode",
     async () => {
       const code = vscode.window.activeTextEditor?.document.getText(
         vscode.window.activeTextEditor?.selection,

--- a/src/commands/getReviewSelectedCodeCustomPromptCommand.ts
+++ b/src/commands/getReviewSelectedCodeCustomPromptCommand.ts
@@ -20,7 +20,7 @@ export const getReviewSelectedCodeCustomPromptCommand = (
   settingsProvider: SettingsProvider,
 ): vscode.Disposable => {
   return vscode.commands.registerCommand(
-    "vs-code-ai-extension.reviewSelectedCodeCustomPrompt",
+    "vscode-byolad.reviewSelectedCodeCustomPrompt",
     async () => {
       const code = vscode.window.activeTextEditor?.document.getText(
         vscode.window.activeTextEditor?.selection,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,11 +11,9 @@ import { getReviewFileCodeCustomPromptCommand } from "./commands/getReviewFileCo
 // This method is called when the extension is activated
 // The extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-  console.log(
-    'Congratulations, your extension "vs-code-ai-extension" is now active!',
-  );
+  console.log('Congratulations, your extension "vscode-byolad" is now active!');
 
-  const config = vscode.workspace.getConfiguration("vs-code-ai-extension");
+  const config = vscode.workspace.getConfiguration("vscode-byolad");
   const settingsProvider = new SettingsProvider(config);
 
   // For commands that have been defined in the package.json file,

--- a/src/helpers/getOnDidChangeConfigurationHandler.ts
+++ b/src/helpers/getOnDidChangeConfigurationHandler.ts
@@ -5,9 +5,9 @@ export const getOnDidChangeConfigurationHandler = (
   settingsProvider: SettingsProvider,
 ): vscode.Disposable => {
   return vscode.workspace.onDidChangeConfiguration((event) => {
-    if (event.affectsConfiguration("vs-code-ai-extension")) {
+    if (event.affectsConfiguration("vscode-byolad")) {
       settingsProvider.setConfig(
-        vscode.workspace.getConfiguration("vs-code-ai-extension"),
+        vscode.workspace.getConfiguration("vscode-byolad"),
       );
     }
   });

--- a/src/helpers/injectCompletionModel.ts
+++ b/src/helpers/injectCompletionModel.ts
@@ -13,9 +13,9 @@ const injectGPTCompletionModel = (
   apiKey?: string,
 ): GPTCompletionModel | UnsetCompletionModel => {
   if (!model || model === "")
-    return injectUnsetCompletionModel("vs-code-ai-extension: Model not set");
+    return injectUnsetCompletionModel("vscode-byolad: Model not set");
   if (!apiKey || apiKey === "")
-    return injectUnsetCompletionModel("vs-code-ai-extension: APIKey not set");
+    return injectUnsetCompletionModel("vscode-byolad: APIKey not set");
 
   return new GPTCompletionModel(model, apiKey);
 };
@@ -25,9 +25,9 @@ const injectPaLMCompletionModel = (
   apiKey?: string,
 ): PaLMCompletionModel | UnsetCompletionModel => {
   if (!model || model === "")
-    return injectUnsetCompletionModel("vs-code-ai-extension: Model not set");
+    return injectUnsetCompletionModel("vscode-byolad: Model not set");
   if (!apiKey || apiKey === "")
-    return injectUnsetCompletionModel("vs-code-ai-extension: APIKey not set");
+    return injectUnsetCompletionModel("vscode-byolad: APIKey not set");
 
   return new PaLMCompletionModel(model, apiKey);
 };
@@ -43,8 +43,6 @@ export const injectCompletionModel = (
     case CompletionProviderType.Google:
       return injectPaLMCompletionModel(model, apiKey);
     default:
-      return injectUnsetCompletionModel(
-        "vs-code-ai-extension: Provider not set",
-      );
+      return injectUnsetCompletionModel("vscode-byolad: Provider not set");
   }
 };


### PR DESCRIPTION
Changes name to byoLAD and the package code to "vscode-byolad" (seems to be a common way other popular extensions name things). Adds some links to the settings and makes the prompt settings multi-line text boxes. Further edit the extension manifest to mark the extension as in preview status, use the icon, and include repo URLs.

Closes #41 